### PR TITLE
Custom Mail Subject

### DIFF
--- a/docs/source/form_setup.rst
+++ b/docs/source/form_setup.rst
@@ -51,23 +51,31 @@ email:
 
     sets outgoing email subject based on the contents of these fields. If both
     fields are available and ``mail_subject_key`` contains a valid field name
-    for another field in the form:
+    for another field in the form, the email subject will be formatted as
+    follows (note that ``mail_subject_key`` sets the subject to the contents of
+    the user input in the field with a name matching the value in
+    ``mail_subject_key``):
     
         form['mail_subject_prefix']: form[form['mail_subject_key']
+        example: Hosting Request: Linux Foundation
     
     If only ``mail_subject_prefix`` is available and valid:
 
         form['mail_subject_prefix']
+        example: Hosting Request
     
     If only ``mail_subject_key`` is available and valid:
 
         form[form['mail_subject_key']]
+        example: Linux Foundation
     
-    If neither fields are available or valid:
+    If neither field is available or valid, the email subject will be set to
+    the default:
 
         'Form Submission'
     
-    These should both be hidden fields
+    ``mail_subject_prefix`` and ``mail_subject_key`` should both be hidden
+    fields
 
     example: 
     

--- a/docs/source/form_setup.rst
+++ b/docs/source/form_setup.rst
@@ -47,13 +47,38 @@ Optional Fields
 Formsender uses some additional optional fields to help format your outgoing
 email:
 
-* **mail_subject**
+* **mail_subject_prefix** and **mail_subject_key**
 
-    sets outgoing email subject to mail_subject's contents. If mail_subject is
-    not included, the subject will default to ``Form Submission``. This should
-    be a hidden field.
+    sets outgoing email subject based on the contents of these fields. If both
+    fields are available and ``mail_subject_key`` contains a valid field name
+    for another field in the form:
+    
+        form['mail_subject_prefix']: form[form['mail_subject_key']
+    
+    If only ``mail_subject_prefix`` is available and valid:
 
-    example: ``<input type="hidden" name="mail_subject" value="FORM: New Test Submission" />``
+        form['mail_subject_prefix']
+    
+    If only ``mail_subject_key`` is available and valid:
+
+        form[form['mail_subject_key']]
+    
+    If neither fields are available or valid:
+
+        'Form Submission'
+    
+    These should both be hidden fields
+
+    example: 
+    
+    .. code-block:: html
+    
+      <input type="hidden" name="mail_subject_prefix" value="Hosting Request" />
+      <input type="hidden" name="mail_subject_key" value="project" />
+      <input type="text" name="project" value="" size="60" maxlength="128" />
+
+    If the user sets the project field to "Linux Foundation" the mail subject
+    will be ``Hosting Request: Linux Foundation``
 
 * **send_to**
 

--- a/request_handler.py
+++ b/request_handler.py
@@ -359,14 +359,37 @@ def convert_key_to_title(snake_case_key):
 
 def set_mail_subject(message):
     """
-    Returns a string to be used as a subject in an email
-    Default is 'Form Submission'
+    Returns a string to be used as a subject in an email, format:
+
+    message['mail_subject_prefix']: message[message['mail_subject_key']
+        or
+    message['mail_subject_prefix']
+        or
+    message[message['mail_subject_key']]
+        or the default
+    'Form Submission'
     """
-    # If key exists in the message dict and has content return the content
-    if 'mail_subject' in message and message['mail_subject']:
-        return message['mail_subject']
-    # Otherwise return default
-    return 'Form Submission'
+    mail_subject = ''
+    # If mail_subject_prefix exists in the message dict and has content, add
+    # it to the mail_subject string. Then check if mail_subject_key also exists
+    # and points to valid data and append if necessary.
+    if 'mail_subject_prefix' in message and message['mail_subject_prefix']:
+        mail_subject += message['mail_subject_prefix']
+        if ('mail_subject_key' in message
+                and message['mail_subject_key']
+                and message['mail_subject_key'] in message
+                and message[message['mail_subject_key']]):
+            mail_subject += ": {}".format(message[message['mail_subject_key']])
+
+    # If mail_subject_key is in the message and the field it points to exists,
+    # add it to the mail_subject. It is ok if it is an empty string, because
+    # it will just be ignored
+    elif ('mail_subject_key' in message
+            and message['mail_subject_key'] in message):
+        mail_subject += message[message['mail_subject_key']]
+
+    # Otherwise mail_subject if it has something or the default
+    return mail_subject if mail_subject else 'Form Submission'
 
 
 def send_to_address(message):

--- a/request_handler.py
+++ b/request_handler.py
@@ -375,17 +375,17 @@ def set_mail_subject(message):
     # and points to valid data and append if necessary.
     if 'mail_subject_prefix' in message and message['mail_subject_prefix']:
         mail_subject += message['mail_subject_prefix']
-        if ('mail_subject_key' in message
-                and message['mail_subject_key']
-                and message['mail_subject_key'] in message
-                and message[message['mail_subject_key']]):
+        if ('mail_subject_key' in message and
+                message['mail_subject_key'] and
+                message['mail_subject_key'] in message and
+                message[message['mail_subject_key']]):
             mail_subject += ": {}".format(message[message['mail_subject_key']])
 
     # If mail_subject_key is in the message and the field it points to exists,
     # add it to the mail_subject. It is ok if it is an empty string, because
     # it will just be ignored
-    elif ('mail_subject_key' in message
-            and message['mail_subject_key'] in message):
+    elif ('mail_subject_key' in message and
+            message['mail_subject_key'] in message):
         mail_subject += message[message['mail_subject_key']]
 
     # Otherwise mail_subject if it has something or the default

--- a/tests.py
+++ b/tests.py
@@ -577,8 +577,9 @@ class TestFormsender(unittest.TestCase):
 
     def test_set_mail_subject_with_both_options(self):
         """
-        set_mail_subject(message) returns the string in message['mail_subject']
-        when it is present, otherwise it returns 'Form Submission'
+        set_mail_subject(message) returns the string
+        "message['mail_subject_prefix']: message[message['mail_subject_key']"
+        when both are available
         """
 
         # Build test environment
@@ -599,8 +600,8 @@ class TestFormsender(unittest.TestCase):
 
     def test_set_mail_subject_with_subj_prefix(self):
         """
-        set_mail_subject(message) returns the string in message['mail_subject']
-        when it is present, otherwise it returns 'Form Submission'
+        set_mail_subject(message) returns the string
+        "message['mail_subject_prefix']" when it is the only field available
         """
 
         # Build test environment
@@ -619,8 +620,9 @@ class TestFormsender(unittest.TestCase):
 
     def test_set_mail_subject_with_subj_key(self):
         """
-        set_mail_subject(message) returns the string in message['mail_subject']
-        when it is present, otherwise it returns 'Form Submission'
+        set_mail_subject(message) returns the string
+        "message[message['mail_subject_prefix']]" when it is the only field
+        available
         """
 
         # Build test environment
@@ -640,8 +642,8 @@ class TestFormsender(unittest.TestCase):
 
     def test_set_mail_subject_with_subj_key_missing(self):
         """
-        set_mail_subject(message) returns the string in message['mail_subject']
-        when it is present, otherwise it returns 'Form Submission'
+        set_mail_subject(message) returns the default string 'Form Submission'
+        when no configuration fields are available
         """
 
         # Build test environment

--- a/tests.py
+++ b/tests.py
@@ -575,7 +575,7 @@ class TestFormsender(unittest.TestCase):
         formatted_message = handler.format_message(message)
         self.assertEqual(formatted_message, target_message)
 
-    def test_set_mail_subject_with_subj(self):
+    def test_set_mail_subject_with_both_options(self):
         """
         set_mail_subject(message) returns the string in message['mail_subject']
         when it is present, otherwise it returns 'Form Submission'
@@ -587,14 +587,76 @@ class TestFormsender(unittest.TestCase):
                                        'email': 'example@osuosl.org',
                                        'redirect': 'http://www.example.com',
                                        'last_name': '',
-                                       'mail_subject': 'Test Form',
+                                       'mail_subject_prefix': 'Hosting',
+                                       'mail_subject_key': 'project',
+                                       'project': 'PGD',
                                        'token': conf.TOKEN})
         env = builder.get_environ()
         req = Request(env)
         # Create message from request and call set_mail_subject()
         message = handler.create_msg(req)
-        subject = handler.set_mail_subject(message)
-        self.assertEqual(subject, 'Test Form')
+        self.assertEqual(handler.set_mail_subject(message), 'Hosting: PGD')
+
+    def test_set_mail_subject_with_subj_prefix(self):
+        """
+        set_mail_subject(message) returns the string in message['mail_subject']
+        when it is present, otherwise it returns 'Form Submission'
+        """
+
+        # Build test environment
+        builder = EnvironBuilder(method='POST',
+                                 data={'name': 'Valid Guy',
+                                       'email': 'example@osuosl.org',
+                                       'redirect': 'http://www.example.com',
+                                       'last_name': '',
+                                       'mail_subject_prefix': 'Hosting',
+                                       'token': conf.TOKEN})
+        env = builder.get_environ()
+        req = Request(env)
+        # Create message from request and call set_mail_subject()
+        message = handler.create_msg(req)
+        self.assertEqual(handler.set_mail_subject(message), 'Hosting')
+
+    def test_set_mail_subject_with_subj_key(self):
+        """
+        set_mail_subject(message) returns the string in message['mail_subject']
+        when it is present, otherwise it returns 'Form Submission'
+        """
+
+        # Build test environment
+        builder = EnvironBuilder(method='POST',
+                                 data={'name': 'Valid Guy',
+                                       'email': 'example@osuosl.org',
+                                       'redirect': 'http://www.example.com',
+                                       'last_name': '',
+                                       'mail_subject_key': 'project',
+                                       'project': 'PGD',
+                                       'token': conf.TOKEN})
+        env = builder.get_environ()
+        req = Request(env)
+        # Create message from request and call set_mail_subject()
+        message = handler.create_msg(req)
+        self.assertEqual(handler.set_mail_subject(message), 'PGD')
+
+    def test_set_mail_subject_with_subj_key_missing(self):
+        """
+        set_mail_subject(message) returns the string in message['mail_subject']
+        when it is present, otherwise it returns 'Form Submission'
+        """
+
+        # Build test environment
+        builder = EnvironBuilder(method='POST',
+                                 data={'name': 'Valid Guy',
+                                       'email': 'example@osuosl.org',
+                                       'redirect': 'http://www.example.com',
+                                       'last_name': '',
+                                       'mail_subject_key': 'project',
+                                       'token': conf.TOKEN})
+        env = builder.get_environ()
+        req = Request(env)
+        # Create message from request and call set_mail_subject()
+        message = handler.create_msg(req)
+        self.assertEqual(handler.set_mail_subject(message), 'Form Submission')
 
     def test_set_mail_subject_with_nothing(self):
         """


### PR DESCRIPTION
Mail subject is set dynamically based on the existence and contents of the two form fields `mail_subject_prefix` and `mail_subject_key`, format of the subject is based upon availability of these fields:

```
message['mail_subject_prefix']: message[message['mail_subject_key']
example: Hosting Request: Python Foundation
```

or

```
message['mail_subject_prefix']
example: Hosting Request
```

or

```
message[message['mail_subject_key']]
example: Python Foundation
```

or the default

```
Form Submission
```
