### PR TITLE
Kennric/email from submitter

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -412,7 +412,10 @@ def set_mail_from(message):
     # If a from address is included in html form, return it
     if 'mail_from' in message and message['mail_from']:
         return message['mail_from']
-    # Otherwise, return from_default
+    # If there is no explicit mail_from, return the  user's submitted email
+    if 'email' in message and message['email']:
+        return message['email']
+    # If neither mail_from nor email is available, return from_default
     return 'from_default'
 
 

--- a/tests.py
+++ b/tests.py
@@ -723,7 +723,7 @@ class TestFormsender(unittest.TestCase):
         # May want to change this email to be something else later on
         self.assertEqual(mail_from, 'randouser@example.org')
 
-    def test_set_mail_from_with_nothing(self):
+    def test_empty_mail_from_uses_email(self):
         """
         set_mail_from(message) returns the string in message['email_from']
         when it is present, otherwise it returns 'default'
@@ -741,7 +741,7 @@ class TestFormsender(unittest.TestCase):
         # Create message from request and call set_mail_subject()
         message = handler.create_msg(req)
         mail_from = handler.set_mail_from(message)
-        self.assertEqual(mail_from, 'from_default')
+        self.assertEqual(mail_from, 'example@osuosl.org')
 
     def test_set_mail_from_with_key_only(self):
         """
@@ -756,6 +756,25 @@ class TestFormsender(unittest.TestCase):
                                        'redirect': 'http://www.example.com',
                                        'last_name': '',
                                        'mail_from': '',
+                                       'token': conf.TOKEN})
+        env = builder.get_environ()
+        req = Request(env)
+        # Create message from request and call set_mail_subject()
+        message = handler.create_msg(req)
+        mail_from = handler.set_mail_from(message)
+        self.assertEqual(mail_from, 'example@osuosl.org')
+
+    def test_mail_from_empty_email_empty(self):
+        """
+        set_mail_from(message) returns the string in message['email_from']
+        when it is present, otherwise it returns 'default'
+        """
+
+        # Build test environment
+        builder = EnvironBuilder(method='POST',
+                                 data={'name': 'Valid Guy',
+                                       'redirect': 'http://www.example.com',
+                                       'last_name': '',
                                        'token': conf.TOKEN})
         env = builder.get_environ()
         req = Request(env)


### PR DESCRIPTION
This PR changes the behavior of formsender:

The 'email' field in the submitted form will be used as the 'from' field in the sent email. 

@ramereth 