### PR TITLE
check_mx will perform unreliable DNS and network queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.swp
 *.pyc
 venv/
+.venv/
+conf.py
 docs/build/

--- a/request_handler.py
+++ b/request_handler.py
@@ -300,8 +300,8 @@ def is_valid_email(request):
     return the email if it is valid, False if not
     """
     valid_email = validate_email(request.form['email'],
-                                 check_mx=True,
-                                 verify=True)
+                                 check_mx=False,
+                                 verify=False)
     if valid_email:
         return valid_email
     return False

--- a/request_handler.py
+++ b/request_handler.py
@@ -48,7 +48,7 @@ class Forms(object):
         try:
             endpoint, values = adapter.match()
             return getattr(self, 'on_' + endpoint)(request, **values)
-        except HTTPException, error:
+        except HTTPException as error:
             self.logger.error('formsender: %s', error)
             return error
 
@@ -300,8 +300,8 @@ def is_valid_email(request):
     return the email if it is valid, False if not
     """
     valid_email = validate_email(request.form['email'],
-                                 check_mx=False,
-                                 verify=False)
+                                 check_mx=False,  # DNS resolution is not reliable
+                                 verify=False)  # disabling RCPT is occasionally used to fight spam
     if valid_email:
         return valid_email
     return False

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [flake8]
-max-line-length = 80
+max-line-length = 120

--- a/tests.py
+++ b/tests.py
@@ -230,19 +230,6 @@ class TestFormsender(unittest.TestCase):
 
         self.assertTrue(handler.is_valid_email(req))
 
-    def test_is_valid_email_with_invalid(self):
-        """
-        Tests is_valid_email with an invalid email
-
-        is_valid_email checks that the email submitted to the form is
-        valid and exists. This function call should return false.
-        """
-        builder = EnvironBuilder(method='POST',
-                                 data={'email': 'nope@example.com'})
-        env = builder.get_environ()
-        req = Request(env)
-        self.assertFalse(handler.is_valid_email(req))
-
     def test_validate_name_with_valid(self):
         """
         Tests validate_name with a valid name


### PR DESCRIPTION
We have a number of [cases](https://sentry.io/osuosl/formsender-prod/issues/248142549/
) where DNS lookup has failed, at which point Formsender does not catch the exception thrown and the POST data is discarded. There's a [number](https://pypi.python.org/pypi/retrying) of [ways](https://www.darkcoding.net/software/choosing-a-message-queue-for-python-on-ubuntu-on-a-vps/) to improve this code, but disabling the check is the fastest way of not dropping customer requests.

Reviewing the [validate_email function](https://github.com/syrusakbary/validate_email/blob/master/validate_email.py#L129), it does two optional things:

- look for an MX record in DNS
- send a RCPT request to the result of the MX lookup for the email address in question

This PR disables network validation of email addresses.