### PR TITLE
string composition from form fields

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -463,6 +463,7 @@ def send_email(msg, subject, send_to_email='default',
     msg_send['Subject'] = subject
     msg_send['To'] = conf.EMAIL[send_to_email]
 
+    # print(msg_send)
     # Sets up a temporary mail server to send from
     smtp = smtplib.SMTP(conf.SMTP_HOST)
     # Attempts to send the mail to EMAIL, with the message formatted as a string

--- a/request_handler.py
+++ b/request_handler.py
@@ -111,7 +111,9 @@ class Forms(object):
             self.error = 'Invalid Name'
             error_number = 2
             invalid_option = 'name'
-        elif not (is_hidden_field_empty(request) and is_valid_token(request)):
+        elif (not (is_hidden_field_empty(request) and
+                   is_valid_token(request)) or
+                not (is_valid_fields_to_join(request))):
             self.error = 'Improper Form Submission'
             error_number = 3
             invalid_option = 'name'
@@ -344,6 +346,18 @@ def is_valid_token(request):
     if request.form['token'] == conf.TOKEN:
         return True
     return False
+
+
+def is_valid_fields_to_join(request):
+    """
+    Make sure that if request has 'fields_to_join' field, that the specified
+    fields to join exist
+    """
+    if 'fields_to_join' in request.form:
+        for field in request.form['fields_to_join'].split(','):
+            if field not in request.form:
+                return False
+    return True
 
 
 def create_error_url(error_number, message, request):

--- a/request_handler.py
+++ b/request_handler.py
@@ -362,7 +362,8 @@ def format_message(msg):
     """Formats a dict (msg) into a nice-looking string"""
     # Ignore these fields when writing to formatted message
     hidden_fields = ['redirect', 'last_name', 'token', 'op',
-                     'name', 'email', 'mail_subject', 'send_to']
+                     'name', 'email', 'mail_subject', 'send_to',
+                     'fields_to_join']
     # Contact information goes at the top
     f_message = ("Contact:\n--------\n"
                  "NAME:   {0}\nEMAIL:   {1}\n"
@@ -374,6 +375,15 @@ def format_message(msg):
         if key not in hidden_fields:
             f_message += ('{0}:\n\n{1}\n\n'.format(convert_key_to_title(key),
                                                    msg[key]))
+    if 'fields_to_join' in msg:
+        # handle fields_to_join
+        for i, field in enumerate(msg['fields_to_join'].split(',')):
+            f_message += msg[field]
+            if i + 1 != len(msg['fields_to_join'].split(',')):
+                f_message += ':'
+            else:
+                f_message += '\n\n'
+
     return f_message
 
 

--- a/request_handler.py
+++ b/request_handler.py
@@ -22,6 +22,7 @@ from datetime import datetime
 import logging
 import logging.handlers
 import conf
+import time
 
 
 class Forms(object):
@@ -355,7 +356,7 @@ def is_valid_fields_to_join(request):
     """
     if 'fields_to_join' in request.form:
         for field in request.form['fields_to_join'].split(','):
-            if field not in request.form:
+            if field not in request.form and field != 'date':
                 return False
     return True
 
@@ -392,8 +393,8 @@ def format_message(msg):
     if 'fields_to_join' in msg:
         # handle fields_to_join
         fields_to_join = msg['fields_to_join'].split(',')  # list of fields
-        f_message += ':'.join(msg[field] for field in fields_to_join) + '\n\n'
-
+        f_message += (
+            ':'.join(str(int(time.time())) if field == 'date' else msg[field] for field in fields_to_join) + '\n\n')
     return f_message
 
 

--- a/request_handler.py
+++ b/request_handler.py
@@ -377,12 +377,8 @@ def format_message(msg):
                                                    msg[key]))
     if 'fields_to_join' in msg:
         # handle fields_to_join
-        for i, field in enumerate(msg['fields_to_join'].split(',')):
-            f_message += msg[field]
-            if i + 1 != len(msg['fields_to_join'].split(',')):
-                f_message += ':'
-            else:
-                f_message += '\n\n'
+        fields_to_join = msg['fields_to_join'].split(',')  # list of fields
+        f_message += ':'.join(msg[field] for field in fields_to_join) + '\n\n'
 
     return f_message
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,7 @@
     <input type="hidden" name="token" value="15674hsda//*q23%^13jnxccv3ds54sa4g4sa532323!OoRdsfISDIdks38*(dsfjk)aS" />
     <input type="hidden" name="redirect" value="http://www.osuosl.org" />
     <input type="hidden" id="edit-submit-mail-sub" name="mail_subject" value="FORM: New Hosting Request" class="form-text" />
+    <input type="hidden" name="fields_to_join" value="email,name" />
     <input type="submit" name="op" value="Submit" />
   </form>
 </body>

--- a/tests.py
+++ b/tests.py
@@ -6,6 +6,7 @@ from werkzeug.test import EnvironBuilder
 from mock import Mock, patch
 from email.mime.text import MIMEText
 import conf
+import time
 import request_handler as handler
 
 
@@ -1069,7 +1070,7 @@ class TestFormsender(unittest.TestCase):
                                        'redirect': 'http://www.example.com',
                                        'last_name': '',
                                        'token': conf.TOKEN,
-                                       'fields_to_join': 'name,email,some_field'})
+                                       'fields_to_join': 'name,email,date,some_field'})
         env = builder.get_environ()
         req = Request(env)
         target_message = ("Contact:\n"
@@ -1080,7 +1081,7 @@ class TestFormsender(unittest.TestCase):
                           "------------\n"
                           "Some Field:\n\n"
                           "This is some info.\n\n"
-                          "Valid Guy:example@osuosl.org:This is some info.\n\n")
+                          "Valid Guy:example@osuosl.org:%s:This is some info.\n\n" % str(int(time.time())))
         message = handler.create_msg(req)
         formatted_message = handler.format_message(message)
         self.assertEqual(formatted_message, target_message)

--- a/tests.py
+++ b/tests.py
@@ -214,6 +214,32 @@ class TestFormsender(unittest.TestCase):
         self.assertEqual(app.error, 'Improper Form Submission')
 
     @patch('request_handler.validate_email')
+    def test_validations_invalid_fields_to_join(self, mock_validate_email):
+        """
+        Tests the form validation with an invalid 'fields_to_join' field.
+
+        on_form_page checks for valid fields in submitted form and
+        returns an error message if an invalid field is found.
+        An invalid token causes the 'Improper Form Submission' error.
+        """
+        builder = EnvironBuilder(method='POST',
+                                 data={'name': 'Valid Guy',
+                                       'email': 'example@osuosl.org',
+                                       'last_name': '',
+                                       'token': conf.TOKEN,
+                                       'redirect': 'http://www.example.com',
+                                       'fields_to_join': 'name,missing,email'})
+        env = builder.get_environ()
+        req = Request(env)
+        # Mock external validate_email so returns true in Travis
+        mock_validate_email.return_value = True
+        app = handler.create_app()
+        # Mock sendmail function so it doesn't send an actual email
+        smtplib.SMTP = Mock('smtplib.SMTP')
+        app.on_form_page(req)
+        self.assertEqual(app.error, 'Improper Form Submission')
+
+    @patch('request_handler.validate_email')
     def test_is_valid_email_with_valid(self, mock_validate_email):
         """
         Tests is_valid_email with a valid email

--- a/tests.py
+++ b/tests.py
@@ -1030,5 +1030,35 @@ class TestFormsender(unittest.TestCase):
 
             self.assertEqual(resp.status_code, 400)
             self.assertEquals(app.error, None)
+
+    def test_string_comp_from_fields_to_join(self):
+        """
+        Tests that values can be pulled from form fields and composed into a
+        string to be included in the body of the email.
+        """
+        builder = EnvironBuilder(method='POST',
+                                 data={'name': 'Valid Guy',
+                                       'email': 'example@osuosl.org',
+                                       'some_field': "This is some info.",
+                                       'redirect': 'http://www.example.com',
+                                       'last_name': '',
+                                       'token': conf.TOKEN,
+                                       'fields_to_join': 'name,email,some_field'})
+        env = builder.get_environ()
+        req = Request(env)
+        target_message = ("Contact:\n"
+                          "--------\n"
+                          "NAME:   Valid Guy\n"
+                          "EMAIL:   example@osuosl.org\n\n"
+                          "Information:\n"
+                          "------------\n"
+                          "Some Field:\n\n"
+                          "This is some info.\n\n"
+                          "Valid Guy:example@osuosl.org:This is some info.\n\n")
+        message = handler.create_msg(req)
+        formatted_message = handler.format_message(message)
+        self.assertEqual(formatted_message, target_message)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
For #77 . Needed for osuosl-pelican's https://github.com/osuosl/osuosl-pelican/issues/159

Changes
- [x] handles a form's ``fields_to_join`` as described in #77 when it is provided
- [x] adds another test similar to the existing test for ``format_message`` that includes a ``fields_to_join`` in the dummy POST request
- [x] validates the ``fields_to_join`` field if it exists

To run tests
- ``make tests``

To "send" a test email (unable to send actual email locally because it would require running a local smtp server)
- in ``request_handler.py``, comment out lines 467-481 and uncomment ``print(msg_send)`` on 466 instead
- Prepare your own test form with a hidden ``fields_to_join`` or use the premade example in ``templates``: navigate to ``templates/`` and do ``python -m SimpleHTTPServer [port num that isn't 5000]``. Make sure your ``form action`` is to localhost:5000. You can also try including a nonexistent field in ``fields_to_join`` to test validation (see below for sample output).
- ``make run`` in another terminal
- got to localhost:[the port num your form is on] in your browser and submit the form. Verify that your ``fields_to_join`` were concatenated correctly if you supplied valid fields. Sample terminal output for ``index.html`` is below.

Expected output
- Tests pass (47)
- Test good "email":
```
(venv) leian@turquoise:~/formsender$ make run
python request_handler.py
 * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
 * Restarting with stat
From nobody Fri Jun  2 16:37:48 2017
Content-Type: text/plain; charset="us-ascii"
MIME-Version: 1.0
Content-Transfer-Encoding: 7bit
Subject: Form Submission
To: support@osuosl.org

Contact:
--------
NAME:   Firstname Lastname
EMAIL:   firstlast@example.com

Information:
------------
firstlast@example.com:Firstname Lastname


127.0.0.1 - - [02/Jun/2017 16:37:48] "POST / HTTP/1.1" 302 -
```
- test bad "email": the email will not print in the terminal. The redirected page upon submission should include something like ?error=3&message=Improper+Form+Submission in the url.

Notes
- Did everything in ``request_handler.py``'s existing ``format_message`` method, but I can make a new method for ``format_message`` to call if needed. 