### PR TITLE
Improve email ordering

### DIFF
--- a/docs/source/form_setup.rst
+++ b/docs/source/form_setup.rst
@@ -55,32 +55,32 @@ email:
     follows (note that ``mail_subject_key`` sets the subject to the contents of
     the user input in the field with a name matching the value in
     ``mail_subject_key``):
-    
+
         form['mail_subject_prefix']: form[form['mail_subject_key']
         example: Hosting Request: Linux Foundation
-    
+
     If only ``mail_subject_prefix`` is available and valid:
 
         form['mail_subject_prefix']
         example: Hosting Request
-    
+
     If only ``mail_subject_key`` is available and valid:
 
         form[form['mail_subject_key']]
         example: Linux Foundation
-    
+
     If neither field is available or valid, the email subject will be set to
     the default:
 
         'Form Submission'
-    
+
     ``mail_subject_prefix`` and ``mail_subject_key`` should both be hidden
     fields
 
-    example: 
-    
+    example:
+
     .. code-block:: html
-    
+
       <input type="hidden" name="mail_subject_prefix" value="Hosting Request" />
       <input type="hidden" name="mail_subject_key" value="project" />
       <input type="text" name="project" value="" size="60" maxlength="128" />
@@ -108,6 +108,46 @@ email:
     field.
 
     example: ``<input type="hidden" name="mail_from" value="randouser@example.org" />``
+
+* **fields_to_join**
+
+    Sets a field that joins other fields' values with colons. The value of the
+    form must be names of existing fields joined by "," (comma). If the value
+    contains field's name that does not exist, an error is returned.
+
+    If the "fields_to_join_name" field is not specified, the joined value will
+    be under title "Fields To Join". If it is specified, the joined value will
+    be under the title of specified value. For more information, please read the
+    "fields_to_join_name" section.
+
+    example: ``<input type="hidden" name="fields_to_join" value="email,project,name" />``
+
+    result section of email:
+
+    .. code-block:: html
+
+      Fields To Join:
+      example@email.com:hosting:John Doe
+
+* **fields_to_join_name**
+
+    Sets the title name of "fields_to_join" field in the email. If not specified,
+    the joined value from "fields_to_join" field will be under title "Field To Join".
+    If it is specified, the joined value will be under the title of specified value.
+
+    example:
+
+    .. code-block:: html
+
+      <input type="hidden" name="fields_to_join" value="email,project,name" />
+      <input type="hidden" name="fields_to_join_name" value="Description" />
+
+    result section of email:
+
+    .. code-block:: html
+
+      Description:
+      example@email.com:hosting:John Doe
 
 All Other Fields
 ----------------

--- a/request_handler.py
+++ b/request_handler.py
@@ -392,9 +392,11 @@ def format_message(msg):
     if 'fields_to_join' in msg:
         # handle fields_to_join
         fields_to_join = msg['fields_to_join'].split(',')  # list of fields
-        joined_data = (':'.join(str(int(time.time())) if field == 'date' else msg[field] for field in fields_to_join) + '\n\n')
+        joined_data = (':'.join(str(int(time.time())) if field == 'date' else msg[field] for field in fields_to_join))
 
-        if 'fields_to_join_name' in msg:
+        # If the fields to join name is specified, and the name does not exist
+        # as a key in current msg dictionary
+        if 'fields_to_join_name' in msg and msg['fields_to_join_name'] not in msg:
             msg[msg['fields_to_join_name']] = joined_data
             msg.pop('fields_to_join', None)
         else:

--- a/request_handler.py
+++ b/request_handler.py
@@ -390,7 +390,7 @@ def format_message(msg):
     # f_message, each key and message is separated by two lines.
     for key in sorted(msg):
         if key not in hidden_fields:
-            f_message += ('{0}:\n\n{1}\n\n'.format(convert_key_to_title(key),
+            f_message += ('{0}:\n{1}\n\n'.format(convert_key_to_title(key),
                                                    msg[key]))
     if 'fields_to_join' in msg:
         # handle fields_to_join

--- a/request_handler.py
+++ b/request_handler.py
@@ -398,9 +398,9 @@ def format_message(msg):
         # as a key in current msg dictionary
         if 'fields_to_join_name' in msg and msg['fields_to_join_name'] not in msg:
             msg[msg['fields_to_join_name']] = joined_data
-            msg.pop('fields_to_join', None)
         else:
-            msg['fields_to_join'] = joined_data
+            msg['Fields To Join'] = joined_data
+        msg.pop('fields_to_join', None)
 
     # Write each formatted key in title case and corresponding message to
     # f_message, each key and message is separated by two lines.

--- a/request_handler.py
+++ b/request_handler.py
@@ -397,17 +397,23 @@ def format_message(msg):
         # If the fields to join name is specified, and the name does not exist
         # as a key in current msg dictionary
         if 'fields_to_join_name' in msg and msg['fields_to_join_name'] not in msg:
-            msg[msg['fields_to_join_name']] = joined_data
+            msg[str(msg['fields_to_join_name'])] = joined_data
         else:
-            msg['Fields To Join'] = joined_data
+            msg[str('Fields To Join')] = joined_data
         msg.pop('fields_to_join', None)
+
+    # Create another dictionary that has lowercase title as key and original
+    # title as value
+    titles = {}
+    for key in msg:
+        titles[key.lower()] = key
 
     # Write each formatted key in title case and corresponding message to
     # f_message, each key and message is separated by two lines.
-    for key in sorted(msg):
+    for key in sorted(titles):
         if key not in hidden_fields:
-            f_message += ('{0}:\n{1}\n\n'.format(convert_key_to_title(key),
-                                                 msg[key]))
+            f_message += ('{0}:\n{1}\n\n'.format(\
+                convert_key_to_title(titles[key]), msg[titles[key]]))
 
     return f_message
 
@@ -489,7 +495,7 @@ def send_email(msg, subject, send_to_email='default',
     msg_send['To'] = conf.EMAIL[send_to_email]
     msg_send['Sender'] = conf.SENDER
 
-    print(msg_send)
+    # print(msg_send)
     # Sets up a temporary mail server to send from
     smtp = smtplib.SMTP(conf.SMTP_HOST)
     # Attempts to send the mail to EMAIL, with the message formatted as a string

--- a/request_handler.py
+++ b/request_handler.py
@@ -412,8 +412,9 @@ def format_message(msg):
     # f_message, each key and message is separated by two lines.
     for key in sorted(titles):
         if key not in hidden_fields:
-            f_message += ('{0}:\n{1}\n\n'.format(\
-                convert_key_to_title(titles[key]), msg[titles[key]]))
+            f_message += \
+                ('{0}:\n{1}\n\n'.format(convert_key_to_title(titles[key]),
+                                        msg[titles[key]]))
 
     return f_message
 

--- a/request_handler.py
+++ b/request_handler.py
@@ -380,23 +380,33 @@ def format_message(msg):
     # Ignore these fields when writing to formatted message
     hidden_fields = ['redirect', 'last_name', 'token', 'op',
                      'name', 'email', 'mail_subject', 'send_to',
-                     'fields_to_join']
+                     'fields_to_join_name']
     # Contact information goes at the top
     f_message = ("Contact:\n--------\n"
                  "NAME:   {0}\nEMAIL:   {1}\n"
                  "\nInformation:\n------------\n"
                  .format(msg['name'], msg['email']))
+
+    # If fields_to_join_name specified, add the key, data to the dictionary
+    # Otherwise, create fields_to_join key, data and add to dictionary
+    if 'fields_to_join' in msg:
+        # handle fields_to_join
+        fields_to_join = msg['fields_to_join'].split(',')  # list of fields
+        joined_data = (':'.join(str(int(time.time())) if field == 'date' else msg[field] for field in fields_to_join) + '\n\n')
+
+        if 'fields_to_join_name' in msg:
+            msg[msg['fields_to_join_name']] = joined_data
+            msg.pop('fields_to_join', None)
+        else:
+            msg['fields_to_join'] = joined_data
+
     # Write each formatted key in title case and corresponding message to
     # f_message, each key and message is separated by two lines.
     for key in sorted(msg):
         if key not in hidden_fields:
             f_message += ('{0}:\n{1}\n\n'.format(convert_key_to_title(key),
                                                  msg[key]))
-    if 'fields_to_join' in msg:
-        # handle fields_to_join
-        fields_to_join = msg['fields_to_join'].split(',')  # list of fields
-        f_message += (
-            ':'.join(str(int(time.time())) if field == 'date' else msg[field] for field in fields_to_join) + '\n\n')
+
     return f_message
 
 
@@ -477,7 +487,7 @@ def send_email(msg, subject, send_to_email='default',
     msg_send['To'] = conf.EMAIL[send_to_email]
     msg_send['Sender'] = conf.SENDER
 
-    # print(msg_send)
+    print(msg_send)
     # Sets up a temporary mail server to send from
     smtp = smtplib.SMTP(conf.SMTP_HOST)
     # Attempts to send the mail to EMAIL, with the message formatted as a string

--- a/request_handler.py
+++ b/request_handler.py
@@ -380,7 +380,8 @@ def format_message(msg):
     # Ignore these fields when writing to formatted message
     hidden_fields = ['redirect', 'last_name', 'token', 'op',
                      'name', 'email', 'mail_subject', 'send_to',
-                     'fields_to_join_name']
+                     'fields_to_join_name', 'support', 'ibm_power',
+                     'mail_subject_prefix', 'mail_subject_key']
     # Contact information goes at the top
     f_message = ("Contact:\n--------\n"
                  "NAME:   {0}\nEMAIL:   {1}\n"

--- a/request_handler.py
+++ b/request_handler.py
@@ -391,7 +391,7 @@ def format_message(msg):
     for key in sorted(msg):
         if key not in hidden_fields:
             f_message += ('{0}:\n{1}\n\n'.format(convert_key_to_title(key),
-                                                   msg[key]))
+                                                 msg[key]))
     if 'fields_to_join' in msg:
         # handle fields_to_join
         fields_to_join = msg['fields_to_join'].split(',')  # list of fields

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,14 +3,25 @@
   <h2>Test Form</h2>
   <form enctype="multipart/form-data" action="http://localhost:5000" method="post" accept-charset="UTF-8">
     <label for="edit-submitted-name">Name</label>
-    <input type="text" name="name" value="" size="60" maxlength="128" />
+    <input type="text" name="name" value="Jerry" size="60" maxlength="128" />
     <label for="edit-submitted-email">Email</label>
-    <input type="text" name="email" value="" size="60" maxlength="128" />
+    <input type="text" name="email" value="jerryp@osuosl.org" size="60" maxlength="128" />
+    <br/>
+    <label for="edit-submitted-1">1</label>
+    <input type="text" name="1" value="First Field!" size="60" maxlength="128" />
+    <label for="edit-submitted-organization">Organization</label>
+    <input type="text" name="organization" value="OSL" size="60" maxlength="128" />
+    <br/>
+    <label for="edit-submitted-distribution">Distribution</label>
+    <input type="text" name="distribution" value="Debian" size="60" maxlength="128" />
+    <label for="edit-submitted-2">2</label>
+    <input type="text" name="2" value="Second Field!" size="60" maxlength="128" />
     <input type="hidden" name="last_name" value="" size="60" />
     <input type="hidden" name="token" value="15674hsda//*q23%^13jnxccv3ds54sa4g4sa532323!OoRdsfISDIdks38*(dsfjk)aS" />
     <input type="hidden" name="redirect" value="http://www.osuosl.org" />
     <input type="hidden" id="edit-submit-mail-sub" name="mail_subject" value="FORM: New Hosting Request" class="form-text" />
-    <input type="hidden" name="fields_to_join" value="email,name" />
+    <input type="hidden" name="fields_to_join_name" value="Eat" />
+    <input type="hidden" name="fields_to_join" value="email,name,distribution,2,date" />
     <input type="submit" name="op" value="Submit" />
   </form>
 </body>

--- a/tests.py
+++ b/tests.py
@@ -1117,7 +1117,8 @@ class TestFormsender(unittest.TestCase):
                           "Some Field:\n"
                           "This is some info.\n\n"
                           "With New Field Name:\n"
-                          "Valid Guy:example@osuosl.org:%s:This is some info.\n\n"% str(int(time.time())))
+                          "Valid Guy:example@osuosl.org:"
+                          "%s:This is some info.\n\n" % str(int(time.time())))
 
         message = handler.create_msg(req)
         formatted_message = handler.format_message(message)

--- a/tests.py
+++ b/tests.py
@@ -1083,9 +1083,11 @@ class TestFormsender(unittest.TestCase):
                           "EMAIL:   example@osuosl.org\n\n"
                           "Information:\n"
                           "------------\n"
+                          "Fields To Join:\n"
+                          "Valid Guy:example@osuosl.org:%s:This is some info.\n\n"
                           "Some Field:\n"
-                          "This is some info.\n\n"
-                          "Valid Guy:example@osuosl.org:%s:This is some info.\n\n" % str(int(time.time())))
+                          "This is some info.\n\n" % str(int(time.time())))
+
         message = handler.create_msg(req)
         formatted_message = handler.format_message(message)
         self.assertEqual(formatted_message, target_message)

--- a/tests.py
+++ b/tests.py
@@ -583,7 +583,7 @@ class TestFormsender(unittest.TestCase):
                           "EMAIL:   example@osuosl.org\n\n"
                           "Information:\n"
                           "------------\n"
-                          "Some Field:\n\n"
+                          "Some Field:\n"
                           "This is multi line and should not be on the same "
                           "line as the title\n\n")
         message = handler.create_msg(req)
@@ -1083,7 +1083,7 @@ class TestFormsender(unittest.TestCase):
                           "EMAIL:   example@osuosl.org\n\n"
                           "Information:\n"
                           "------------\n"
-                          "Some Field:\n\n"
+                          "Some Field:\n"
                           "This is some info.\n\n"
                           "Valid Guy:example@osuosl.org:%s:This is some info.\n\n" % str(int(time.time())))
         message = handler.create_msg(req)

--- a/tests.py
+++ b/tests.py
@@ -1092,6 +1092,36 @@ class TestFormsender(unittest.TestCase):
         formatted_message = handler.format_message(message)
         self.assertEqual(formatted_message, target_message)
 
+    def test_string_comp_with_fields_to_join_name(self):
+        """
+        Tests that value from fields_to_join_name field can be used as keys for
+        fields_to_join data
+        """
+        builder = EnvironBuilder(method='POST',
+                                 data={'name': 'Valid Guy',
+                                       'email': 'example@osuosl.org',
+                                       'some_field': "This is some info.",
+                                       'redirect': 'http://www.example.com',
+                                       'last_name': '',
+                                       'token': conf.TOKEN,
+                                       'fields_to_join_name': 'With New Field Name',
+                                       'fields_to_join': 'name,email,date,some_field'})
+        env = builder.get_environ()
+        req = Request(env)
+        target_message = ("Contact:\n"
+                          "--------\n"
+                          "NAME:   Valid Guy\n"
+                          "EMAIL:   example@osuosl.org\n\n"
+                          "Information:\n"
+                          "------------\n"
+                          "Some Field:\n"
+                          "This is some info.\n\n"
+                          "With New Field Name:\n"
+                          "Valid Guy:example@osuosl.org:%s:This is some info.\n\n"% str(int(time.time())))
+
+        message = handler.create_msg(req)
+        formatted_message = handler.format_message(message)
+        self.assertEqual(formatted_message, target_message)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Issue #85 

Changes: 
- Removed a newline character so the data comes right after the keyword and the colon.
- Created fields_to_join_name field to configure field name for joined data
- Upper case titles are sorted in their lowercase value
- Added new test for fields_to_join_name values
- Documentation updated, with fields_to_join and fields_to_join_name section for form_setup.rst

The keywords are already programmed to sort keys when I was fixing it.