### PR TITLE
Remove g-recaptcha-response from the message that gets sent

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -409,7 +409,8 @@ def format_message(msg):
     hidden_fields = ['redirect', 'last_name', 'token', 'op',
                      'name', 'email', 'mail_subject', 'send_to',
                      'fields_to_join_name', 'support', 'ibm_power',
-                     'mail_subject_prefix', 'mail_subject_key']
+                     'mail_subject_prefix', 'mail_subject_key',
+                     'g-recaptcha-response']
     # Contact information goes at the top
     f_message = ("Contact:\n--------\n"
                  "NAME:   {0}\nEMAIL:   {1}\n"


### PR DESCRIPTION
Add `g-recaptcha-response` to list of hidden_fields so it won't get automatically formatted and inserted into the outgoing email.