### PR TITLE
Upgrade flake8 and other dependancies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ MarkupSafe==2.1.3
 mccabe==0.7.0
 mock==5.1.0
 pycodestyle==2.11.0
-pyflakes==3.0.1
+pyflakes==3.1.0
 requests-toolbelt==1.0.0
 rt==3.0.7
 six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 certifi==2023.7.22
 charset-normalizer==3.2.0
-flake8==6.0.0
+flake8==6.1.0
 gunicorn==21.2.0
 idna==3.4
 Jinja2==3.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Jinja2==3.1.2
 MarkupSafe==2.1.3
 mccabe==0.7.0
 mock==5.1.0
-pycodestyle==2.10.0
+pycodestyle==2.11.0
 pyflakes==3.0.1
 requests-toolbelt==1.0.0
 rt==3.0.7


### PR DESCRIPTION
We need to do this in a single PR due to them depending on each other.

- Bump flake8 from 6.0.0 to 6.1.0
- Bump pycodestyle from 2.10.0 to 2.11.0
- Bump pyflakes from 3.0.1 to 3.1.0
