### PR TITLE
Hugo migration: form returns an immutablemultidict, change request_handler to handle accordingly

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -308,7 +308,7 @@ def create_msg(request):
         # dict. request.form cannot be returned directly because it is a
         # multidict.
         for key in request.form:
-            message[key] = request.form[key]
+            message[key] = request.form.get(key)
         # If there is a message, return it, otherwise return None
         if message:
             message['redirect'] = strip_query(message['redirect'])


### PR DESCRIPTION
Instead of using `request.form` as a dict (how pelican submits the form), Hugo submits request.form as an ImmutableMultiDict. The only change to request_handler.py, then, is to change how we grab data from request.form (request.form[key] vs request.form.get(key)).