### PR TITLE
Switch to python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,9 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
+          - "3.11"
+          - "3.12"
 
     steps:
       - uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine
+FROM python:3.11-alpine
 
 COPY conf.py.dist /formsender/conf.py
 COPY requirements.txt /formsender/requirements.txt


### PR DESCRIPTION
Also update the python test matrix to add 3.11 and 3.12 and remove 3.9.

Signed-off-by: Lance Albertson <lance@osuosl.org>
